### PR TITLE
modify AutoBugTracker and ExecuteUserScript

### DIFF
--- a/src/AutoBugTracker.py
+++ b/src/AutoBugTracker.py
@@ -7,6 +7,7 @@ import src.DatabaseScript as initializeDatabaseScript
 import src.EmailUsers as emailUsers
 from decouple import config
 
+
 class AutoBugTracker(object):
     def __init__(self):
         print("***Auto Bug Tracker***\n")
@@ -16,7 +17,7 @@ class AutoBugTracker(object):
         # Gets configuration file, if non existent it will create one
         self.configOptions = readConfig.readConfig()
         self.logs = debugLogFile.DebugLogFile(self.configOptions)
-        self.execute = ExecuteUserScript.ExecuteUserScript()
+        self.execute = ExecuteUserScript.ExecuteUserScript(self.configOptions, self.logs)
         self.github = None
         self.email = None
 
@@ -105,11 +106,12 @@ class AutoBugTracker(object):
 
         it does sort functions of the class in logical order for execution.
         """
+        github = self.githubConfiguration()
         scriptName = self.parsingCommandLineArguments()['userScript']
         traceBackOfParentProgram = self.execute.executeScript(scriptName)
-        # return list of traceback to be included in user email
-        # return execute if (type(execute) is list) else None
-        self.sendEmail(traceBackOfParentProgram)
+        if (type(traceBackOfParentProgram) is list):
+            self.database.list_insert(("", "", traceBackOfParentProgram, False))
+            self.sendEmail(traceBackOfParentProgram)
 
 
 if __name__ == '__main__':

--- a/src/ExecuteUserScript.py
+++ b/src/ExecuteUserScript.py
@@ -1,23 +1,53 @@
+import sys
 import traceback
 
 
 class ExecuteUserScript(object):
+    def __init__(self, configOptions, logs):
+        self.configOptions = configOptions
+        self.logs = logs
+
+    def captureTraceback(self):
+        """Display the exception that just occurred.
+
+        return:
+            list with the traceback
+
+        """
+        try:
+            type, value, tb = sys.exc_info()
+            sys.last_type = type
+            sys.last_value = value
+            sys.last_traceback = tb
+            tblist = traceback.extract_tb(tb)
+            del tblist[:1] # removing AutoBugTracker stack line
+            tracebackList = traceback.format_list(tblist)
+            if tracebackList:
+                tracebackList.insert(0, "Traceback (most recent call last):\n")
+            tracebackList[len(tracebackList):] = traceback.format_exception_only(type, value)
+        finally:
+            tblist = tb = None
+        return tracebackList
 
     def executeScript(self, scriptName):
-        """
-        Return list of traceback stack
+        """ Execute parent program
 
-        execute user script, takes script to be execute as an argument
-        either graceful execution or bug information such as capturing traceback
+            execute user script, takes script to execute as an argument
+            either graceful execution or bug information such as capturing traceback
+
+        Return:
+             list of traceback stack if user program crash
+
         """
         try:
             return exec(open(scriptName).read())
         except FileNotFoundError:
             print(f'{scriptName} script is not found!')
+            self.logs.writeToFile(message=self.captureTraceback())
         except ModuleNotFoundError as e:
             print(f'{e}, module is not found!')
+            self.logs.writeToFile(message=self.captureTraceback())
             # Blacklist the script with missing module and notify user. Do not submit Bug!
         except:
             print(f'{scriptName} did not exit gracefully, Submit a Bug!"')
-            # traceback.print_exc(file=sys.stdout)
-            return list(traceback.extract_stack())
+            return self.captureTraceback()


### PR DESCRIPTION
The following changes have been made to the AutoBugTracker:

1- capturing the traceback for the crashed script from ExecuteUserScrip. 
2- send the traceback via email ,
3- send the traceback to the database, utilize the third element in the bugRecord tuple. We need to discuss the other elements. 
4- AutoBugTracker knows the script did not exist gracefully when the return value from ExecuteUserScript is a list. 

The following changes have been made to the ExecuteUserScript. 
1- create a function to digest the exact traceback for the crashed script. 
2- add debug option for
    a) when file does not exist. 
    b) when library missing 
3- capture the traceback when parent script crashed format in a list. 
   a) remove our script name from the list and make it pure for the crashed parent script. 

[AB#146](https://dev.azure.com/dhk2/65e21a49-896d-470d-8659-fc7cca2f4625/_workitems/edit/146)